### PR TITLE
Enhance .gitignore for C and assembler files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,18 @@
+# Created by https://www.toptal.com/developers/gitignore/api/c,assembler
+# Edit at https://www.toptal.com/developers/gitignore?templates=c,assembler
+
+### Assembler ###
+*.exe
+*.o
+*.obj
+*.bc
+
+### C ###
 # Prerequisites
 *.d
 
 # Object files
-*.o
 *.ko
-*.obj
 *.elf
 
 # Linker output
@@ -29,7 +37,6 @@
 *.dylib
 
 # Executables
-*.exe
 *.out
 *.app
 *.i*86
@@ -51,5 +58,4 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
-# debug information files
-*.dwo
+# End of https://www.toptal.com/developers/gitignore/api/c,assembler


### PR DESCRIPTION
Updated .gitignore to include assembler and C file patterns.